### PR TITLE
HOTFIX: Breaking change on dependency

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -3,7 +3,7 @@ import _ from 'lodash';
 import tv4 from 'tv4';
 import jsonapi from './schemas/jsonapi.json';
 import {ArgumentError} from './errors';
-import Serializer from 'jsonapi-serializer';
+import {Serializer} from 'jsonapi-serializer';
 
 class Model {
   constructor(values = {}, schema = false, Instancier = Model) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "javascript-jsonapi-model-library",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Provide base model to deal with jsonapi models",
   "homepage": "",
   "author": {
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "js-yaml": "^3.5.2",
-    "jsonapi-serializer": "^2.0.4",
+    "jsonapi-serializer": "^3.0.1",
     "lodash": "^4.0.0",
     "tv4": "^1.2.7"
   }


### PR DESCRIPTION
#### What's this PR purpose?

jsonapi-serializer published a 2.x containing some breaking change. It breaks our lib, instead of forcing to 2.0.4 we update to the last version.
